### PR TITLE
Develop

### DIFF
--- a/Model/Rule/Condition/Address.php
+++ b/Model/Rule/Condition/Address.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace MagestyApps\FixRules\Model\Rule\Condition;
+
+class Address extends \Magento\SalesRule\Model\Rule\Condition\Address
+{
+    /**
+     * Load attribute options
+     *
+     * @return $this
+     */
+    public function loadAttributeOptions()
+    {
+        $attributes = [
+            'base_subtotal' => __('Subtotal'),
+            'total_qty' => __('Total Items Quantity'),
+            'weight' => __('Total Weight'),
+            'shipping_method' => __('Shipping Method'),
+            'payment_method' => __('Payment Method'),
+            'postcode' => __('Shipping Postcode'),
+            'region' => __('Shipping Region'),
+            'region_id' => __('Shipping State/Province'),
+            'country_id' => __('Shipping Country'),
+        ];
+
+        $this->setAttributeOption($attributes);
+
+        return $this;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # magento2-fix-discount-rules
-If you try to create a new discount rule in Magento 2, you'll see a condition called "Payment Method" there. This condition means that the discount will be applied in case a customer selects a certain payment method. But actually, this rule will not work due to a small omission in Magento 2 checkout. The module in the repo fixes the issue.
+If you try to create a new discount rule by "Payment Method" in Magento 2.1.8 +, you'll notice that option "Payment Method" in rules options is no longer available. The Magento team members have removed this option due to a bug. This condition means that the discount will be applied in case a customer selects a certain payment method. But actually, this rule will not work due to a small omission in Magento 2 checkout, that's the razon why core team removed this option. The module in the repo fixes both cases, turns the option visible again and corrects its behavior.
+
 ## How to install:
 * Create folder 'app/code/MagestyApps/FixRules/' in you Magento setup
 * Extract the repo files to the folder
@@ -12,7 +13,9 @@ If you try to create a new discount rule in Magento 2, you'll see a condition ca
 * Install the new module using the command below:
    ```
    php bin/magento setup:upgrade
+   php bin/magento setup:di:compile
    ```
 
 ## Description
 You can find some code explanations in our blog post: ["Cart Price Rules Based on Payment Method Don't Work"](https://www.magestyapps.com/blog/post/issue-cart-price-rules-based-on-payment-method-dont-work/)
+And here a [stack overflow question](https://magento.stackexchange.com/questions/193645/why-was-cart-price-rule-based-on-payment-method-removed-from-magento-2-1-8) about the remotion of this option.

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+     <preference for="Magento\SalesRule\Model\Rule\Condition\Address" type="MagestyApps\FixRules\Model\Rule\Condition\Address" />
+</config>


### PR DESCRIPTION
Adds rules by "Payment Method" again, which was removed in version 2.1.8, and changes readme to inform this situation.